### PR TITLE
fix(vercel): Vite dist + SPA fallback

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,8 @@
 {
-  "version": 2,
-  "builds": [
-    {
-      "src": "build/**/*",
-      "use": "@vercel/static"
-    }
-  ],
-  "routes": [
-    { "handle": "filesystem" },
-    { "src": "/(.*)", "dest": "/build/index.html" }
+  "framework": "vite",
+  "buildCommand": "pnpm build || npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
Ajusta vercel.json para framework Vite, output 'dist' e SPA fallback. Dispara redeploy do projeto do site.